### PR TITLE
fix: guard command response parsing against non-matching messages

### DIFF
--- a/src/entity/player.ts
+++ b/src/entity/player.ts
@@ -73,7 +73,8 @@ export class Player {
     const res = await this.world.runCommand(`tag "${this.rawName}" list`);
     if (res.statusCode < CommandStatusCode.Success) throw new Error(res.statusMessage);
 
-    const tags = res.statusMessage.match(/§a.*?§r/g)!
+    // When the player has no tags, the response contains no §a...§r segments and match() returns null
+    const tags = (res.statusMessage.match(/§a.*?§r/g) ?? [])
       .map(str => str.replace(/§a|§r/g, ''));
     return tags;
   }

--- a/src/world/scoreboard/scoreboard.ts
+++ b/src/world/scoreboard/scoreboard.ts
@@ -19,8 +19,11 @@ export class Scoreboard {
     const res = await this.world.runCommand('scoreboard objectives list');
     if (res.statusCode < CommandStatusCode.Success) throw new Error(res.statusMessage);
 
-    const objectives = res.statusMessage.split('\n').slice(1).map(entry => {
-      const [ id, displayName ] = [...entry.matchAll(/- (.*):.*?'(.*?)'.*/g)][0].slice(1,3);
+    const objectives = res.statusMessage.split('\n').slice(1).flatMap(entry => {
+      // Skip lines that don't match the expected format instead of crashing on [0] being undefined
+      const matched = [...entry.matchAll(/- (.*):.*?'(.*?)'.*/g)][0];
+      if (!matched) return [];
+      const [ id, displayName ] = matched.slice(1,3);
       let objective = this.objectives.get(id);
       if (objective) {
         // @ts-expect-error overwrite displayName internally
@@ -86,7 +89,9 @@ export class Scoreboard {
     try {
       return Object.fromEntries(
         [...res.statusMessage.matchAll(/: (-*\d*) \((.*?)\)/g)]
-          .map(data => [data[2], data ? Number(data[1]) : null])
+          // data is the match array (always truthy) — check the captured value instead,
+          // so a missing score becomes null rather than Number('') === 0
+          .map(data => [data[2], data[1] ? Number(data[1]) : null])
       );
     } catch {
       return {};


### PR DESCRIPTION
コマンド応答のパースで、match 結果のガードが無い（または誤っている）箇所を3つ修正しました。

## 1. `Player.getTags()` — タグ0件で TypeError（実際に踏みました）

タグを持たないプレイヤーで `getTags()` / `hasTag()` を呼ぶと、応答に `§a...§r` が含まれず `match()` が `null` を返すため `Cannot read properties of null (reading 'map')` で落ちます。`?? []` でガードして空配列を返すようにしました（`hasTag()` は `false` になります）。

## 2. `Scoreboard.getObjectives()` — 一致しない行で TypeError

`[...entry.matchAll(...)][0]` が `undefined` になる行（形式差・ローカライズ等）があると `.slice` で落ちるため、一致しない行はスキップするようにしました（`map` → `flatMap`）。

## 3. `Scoreboard.getScores()` — 常に真の条件式

`data ? Number(data[1]) : null` の `data` は match 結果の配列で常に truthy のため `: null` に到達せず、値が取れなかったスコアが `null` ではなく `Number('') === 0` になっていました。戻り値の型（`Record<string, number | null>`）どおり `data[1]` を見るようにしました。

## 確認

- `pnpm run lint`（oxlint）: 0 エラー
- `pnpm run build`（tsdown）: 成功
- 1 は MakeNode（socket-be を使ったビジュアルプログラミングツール）の開発中に実機で踏んだものです。2・3 はコードリーディングでの発見で、修正版での実機再現確認はしていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
