### PR TITLE
Add public methods for event re-subscription

### DIFF
--- a/src/events/event-signal.ts
+++ b/src/events/event-signal.ts
@@ -13,7 +13,6 @@ export class EventSignal {
   public readonly server: Server;
   
   public emit(): boolean {
-    // @ts-expect-error - "this" should be correct type
     return this.server.emit(this.identifier, this);
   }
 

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -19,6 +19,8 @@ export * from './player-teleported';
 export * from './player-title';
 export * from './player-transform';
 export * from './player-travelled';
+export * from './server-close';
+export * from './server-open';
 export * from './target-block-hit';
 export * from './world-add';
 export * from './world-event-signal';

--- a/src/events/server-close.ts
+++ b/src/events/server-close.ts
@@ -1,0 +1,6 @@
+import { ServerEvent } from '../enums';
+import { EventSignal } from './event-signal';
+
+export class ServerCloseSignal extends EventSignal {
+  public static readonly identifier: ServerEvent = ServerEvent.Close;
+}

--- a/src/events/server-open.ts
+++ b/src/events/server-open.ts
@@ -1,0 +1,6 @@
+import { ServerEvent } from '../enums';
+import { EventSignal } from './event-signal';
+
+export class ServerOpenSignal extends EventSignal {
+  public static readonly identifier: ServerEvent = ServerEvent.Open;
+}

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -96,7 +96,7 @@ export class Network extends ExtendedEmitter<NetworkEvents> {
 
     this.server.worlds.set(connection, world);
 
-    this.refreshEventSubscriptions();
+    this.sendEventSubscriptions(connection);
 
     world.onConnect();
   }
@@ -247,29 +247,40 @@ export class Network extends ExtendedEmitter<NetworkEvents> {
     }
   }
 
-  /**
-   * Send EventSubscribePacket for all registered events to all connected worlds.
-   * This can also be used to resubscribe events after a world is connected.
-   */
-  public refreshEventSubscriptions() {
-    const events = new Set<Packet>();
+  private getSubscribedPacketIds(): Set<Packet> {
+    const subscribedPacketIds = new Set<Packet>();
     for (const registered of this.server.getRegisteredEvents()) {
       for (const packetId of Network.getPacketIdsByEvent(registered)) {
-        events.add(packetId);
+        subscribedPacketIds.add(packetId);
       }
     }
 
     for (const packetId of this.getRegisteredEvents()) {
       if (packetId === 'all' || packetId === 'raw') continue;
-      events.add(packetId);
+      subscribedPacketIds.add(packetId);
     }
 
-    for (const eventName of events) {
+    return subscribedPacketIds;
+  }
+
+  /**
+   * Send EventSubscribePacket for all registered events to a single connection.
+   */
+  public sendEventSubscriptions(connection: Connection) {
+    for (const packetId of this.getSubscribedPacketIds()) {
       const packet = new EventSubscribePacket();
-      packet.eventName = eventName;
-      for (const connection of this.connections) {
-        this.send(connection, packet);
-      }
+      packet.eventName = packetId;
+      this.send(connection, packet);
+    }
+  }
+
+  /**
+   * Send EventSubscribePacket for all registered events to all connected worlds.
+   * Can be used to resubscribe when new events are registered.
+   */
+  public refreshEventSubscriptions() {
+    for (const connection of this.connections) {
+      this.sendEventSubscriptions(connection);
     }
   }
 

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -76,7 +76,7 @@ export class Network extends ExtendedEmitter<NetworkEvents> {
   }
 
   public onListening() {
-    this.server.emit(ServerEvent.Open);
+    new events.ServerOpenSignal(this.server).emit();
   }
 
   public async onConnection(ws: WebSocket) {
@@ -250,7 +250,7 @@ export class Network extends ExtendedEmitter<NetworkEvents> {
     
   public onClose() {
     this.connections.clear();
-    this.server.emit(ServerEvent.Close);
+    new events.ServerCloseSignal(this.server).emit();
   }
 
   public registerHandler(handler: typeof NetworkHandler) {

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -96,7 +96,7 @@ export class Network extends ExtendedEmitter<NetworkEvents> {
 
     this.server.worlds.set(connection, world);
 
-    this.refleshEventSubscriptions();
+    this.refreshEventSubscriptions();
 
     world.onConnect();
   }

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -93,29 +93,10 @@ export class Network extends ExtendedEmitter<NetworkEvents> {
     }
 
     new events.WorldAddSignal(world).emit();
-    
+
     this.server.worlds.set(connection, world);
 
-    // send all registered events
-    const registeredEvents: Set<Packet | 'all' | 'raw'> = this.getRegisteredEvents();
-
-    for (const registered of this.server.getRegisteredEvents()) {
-      // get subscribed EventSignal class
-      const Signal = Object.values(events).find(Signal => Signal.identifier === registered);
-      if (!Signal) continue;
-      for (const packetId of Signal.packets) {
-        registeredEvents.add(packetId);
-      }
-    }
-
-    for (const registered of registeredEvents) {
-      if (registered === 'all' || registered === 'raw') continue;
-
-      const packet = new EventSubscribePacket();
-      packet.eventName = registered;
-
-      this.send(connection, packet);
-    }
+    this.refleshEventSubscriptions();
 
     world.onConnect();
   }
@@ -264,5 +245,37 @@ export class Network extends ExtendedEmitter<NetworkEvents> {
         break;
       }
     }
+  }
+
+  /**
+   * Send EventSubscribePacket for all registered events to all worlds.
+   * This can be also used to resubscribe events after a world is connected.
+   */
+  public refleshEventSubscriptions() {
+    const events = new Set<Packet>();
+    for (const registered of this.server.getRegisteredEvents()) {
+      for (const packetId of Network.getPacketIdsByEvent(registered)) {
+        events.add(packetId);
+      }
+    }
+
+    for (const packetId of this.getRegisteredEvents()) {
+      if (packetId === 'all' || packetId === 'raw') continue;
+      events.add(packetId);
+    }
+
+    for (const eventName of events) {
+      const packet = new EventSubscribePacket();
+      packet.eventName = eventName;
+      for (const connection of this.connections) {
+        this.send(connection, packet);
+      }
+    }
+  }
+
+  public static getPacketIdsByEvent(event: ServerEvent) {
+    const Signal = Object.values(events).find(Signal => Signal.identifier === event);
+    if (!Signal) throw new Error(`No Event class found for event ${ServerEvent[event]}`);
+    return Signal.packets;
   }
 }

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -248,10 +248,10 @@ export class Network extends ExtendedEmitter<NetworkEvents> {
   }
 
   /**
-   * Send EventSubscribePacket for all registered events to all worlds.
-   * This can be also used to resubscribe events after a world is connected.
+   * Send EventSubscribePacket for all registered events to all connected worlds.
+   * This can also be used to resubscribe events after a world is connected.
    */
-  public refleshEventSubscriptions() {
+  public refreshEventSubscriptions() {
     const events = new Set<Packet>();
     for (const registered of this.server.getRegisteredEvents()) {
       for (const packetId of Network.getPacketIdsByEvent(registered)) {

--- a/src/types/events/events.ts
+++ b/src/types/events/events.ts
@@ -24,11 +24,13 @@ import type {
   PlayerTeleportedSignal,
   PlayerTransformSignal,
   TargetBlockHitSignal,
+  ServerOpenSignal,
+  ServerCloseSignal,
 } from '../../events';
 
 export interface ServerEvents {
-  [ServerEvent.Open]: [];
-  [ServerEvent.Close]: [];
+  [ServerEvent.Open]: [ServerOpenSignal];
+  [ServerEvent.Close]: [ServerCloseSignal];
   [ServerEvent.WorldAdd]: [WorldAddSignal];
   [ServerEvent.WorldRemove]: [WorldRemoveSignal];
   [ServerEvent.WorldInitialize]: [WorldInitializeSignal];


### PR DESCRIPTION
## Added

- `Network#refleshEventSubscriptions()`
  - Broadcast EventSubscribePacket for all registered events to all connected worlds
  - Can be used to resubscribe events after a world is connected. 
- `Network#sendEventSubscriptions(connection: Connection)`
- `Network.getPacketIdsByEvent(event: ServerEvent)` (static)

## Other improvements

* Updated `ServerEvents` interface to specify that `ServerEvent.Open` and `ServerEvent.Close` now use the new `ServerOpenSignal` and `ServerCloseSignal`, improving type safety.