### PR TITLE
fix(world): getOrCreateAgent がエージェントをキャッシュせず毎回作り直す

### DIFF
--- a/src/world/world.ts
+++ b/src/world/world.ts
@@ -367,11 +367,20 @@ export class World {
     return res.data;
   }
 
+  /**
+   * Returns this world's agent, summoning one if it does not have it yet.
+   *
+   * @remarks
+   * This can spawn an entity, so it is not safe to call from a read path. To find out where
+   * an existing agent is without creating one, run `querytarget @e[type=agent]` and read the
+   * `details` field of the response.
+   */
   public async getOrCreateAgent(): Promise<Agent> {
     if (this.agent) return this.agent;
     const res = await this.runCommand('agent create');
     if (res.statusCode < CommandStatusCode.Success) throw new Error(res.statusMessage);
-    return new Agent(this);
+    this.agent = new Agent(this);
+    return this.agent;
   }
   
   private async updatePlayerList(isFirst = false) {


### PR DESCRIPTION
## 問題

`World#getOrCreateAgent()` は 1 行目で `this.agent` を見ていますが、**このフィールドはどこからも代入されていません**。そのためガードが成立せず、呼ぶたびに `agent create` が飛びます。

```ts
public async getOrCreateAgent(): Promise<Agent> {
  if (this.agent) return this.agent;   // ← 常に falsy
  const res = await this.runCommand('agent create');
  if (res.statusCode < CommandStatusCode.Success) throw new Error(res.statusMessage);
  return new Agent(this);              // ← 代入していない
}
```

## 影響

余計なコマンドが増えるだけでは済みません。既存のエージェントに触るつもりで呼んだ場合 — 位置を読む、移動させる — **そのたびにプレイヤーの隣に新しいエージェントが湧きます**。

「エージェントはどこにいるか」を尋ねたつもりが、尋ねた結果ワールドが変わってしまう、という形になります。

## 修正

インスタンスを代入して、書かれているとおりにガードを効かせます。

あわせて JSDoc を追加しました。このメソッドがエンティティを湧かせうることを明示し、**作らずに位置だけ知りたい場合の代替**として `querytarget @e[type=agent]` を案内しています（応答の `details` に位置が入ります）。読み取り目的で呼ばれるのを防ぐためです。

## 確認

- `tsdown` によるビルド通過
- `oxlint --type-aware --type-check` の指摘は変更前後で同一（既存の警告のみ）

変更は `src/world/world.ts` の 1 メソッドのみです。