### PR TITLE
fix(block-placed): コマンド由来の設置イベントが握り潰されている

### DIFF
--- a/src/enums/block-placement-method.ts
+++ b/src/enums/block-placement-method.ts
@@ -1,0 +1,4 @@
+export enum BlockPlacementMethod {
+  Player = 0,
+  Command = 1,
+}

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -1,5 +1,6 @@
 export * from './ability-type';
 export * from './agent-direction';
+export * from './block-placement-method';
 export * from './command-status-code';
 export * from './command-version';
 export * from './display-slot-id';

--- a/src/events/block-placed.ts
+++ b/src/events/block-placed.ts
@@ -1,4 +1,4 @@
-import { Packet, ServerEvent } from '../enums';
+import { BlockPlacementMethod, Packet, ServerEvent } from '../enums';
 import { WorldEventSignal } from './world-event-signal';
 import type { World } from '../world';
 import type { Player } from '../entity';
@@ -7,50 +7,53 @@ import type { WorldPlayer } from '../types';
 import type { BlockType } from '../block';
 
 /**
- * Fired when a block is placed, whether by a player or by a command.
+ * Fired when a block is placed by a player or a command.
  *
  * @remarks
- * A command-driven placement carries no player: `setblock` produces a frame with only
- * `block`, `count`, `placementMethod` and `tool`. {@link player}, {@link rawPlayer} and
- * {@link placedUnderwater} are therefore `undefined` for those, so check `player` before
- * reading it. Note also that `setblock <pos> air` reports as a placement of `air` rather
- * than as a {@link BlockBrokenSignal}, and that `setblock <pos> air destroy` fires nothing
- * at all.
+ * Use {@link placementMethod} to determine which placement data is available.
+ * When it is {@link BlockPlacementMethod.Command}, {@link placedUnderwater},
+ * {@link player}, {@link rawPlayer}, and {@link itemStackBeforePlace} are `undefined`.
+ *
+ * `setblock <pos> air` is reported as a placement of `air`, rather than as a
+ * {@link BlockBrokenSignal}. `setblock <pos> air destroy` does not fire either event.
  */
 export class BlockPlacedSignal extends WorldEventSignal {
   public static readonly identifier: ServerEvent = ServerEvent.BlockPlaced;
 
   public static readonly packets: Packet[] = [Packet.BlockPlaced];
 
+  /** The type of block that was placed. */
   public readonly placedBlockType: BlockType;
 
-  /** `undefined` for a command-driven placement. */
+  /** How the block was placed. Determines which placement data is available. */
+  public readonly placementMethod: BlockPlacementMethod;
+
+  /** Whether the block was placed underwater, or `undefined` for a command placement. */
   public readonly placedUnderwater?: boolean;
 
-  public readonly placementMethod: number;
-
-  /** The player who placed the block, or `undefined` for a command-driven placement. */
+  /** The player who placed the block, or `undefined` for a command placement. */
   public readonly player?: Player;
 
-  /** The raw player frame, or `undefined` for a command-driven placement. */
+  /** The raw player data, or `undefined` for a command placement. */
   public readonly rawPlayer?: WorldPlayer;
 
-  public readonly itemStackBeforePlace: ItemStack;
+  /** The item held before the block was placed, or `undefined` for a command placement. */
+  public readonly itemStackBeforePlace?: ItemStack;
 
   public constructor(
     world: World,
     placedBlockType: BlockType,
-    placedUnderwater: boolean | undefined,
-    placementMethod: number,
-    player: Player | undefined,
-    rawPlayer: WorldPlayer | undefined,
-    itemStackBeforePlace: ItemStack,
+    placementMethod: BlockPlacementMethod,
+    placedUnderwater?: boolean,
+    player?: Player,
+    rawPlayer?: WorldPlayer,
+    itemStackBeforePlace?: ItemStack,
   ) {
     super(world);
 
     this.placedBlockType = placedBlockType;
-    this.placedUnderwater = placedUnderwater;
     this.placementMethod = placementMethod;
+    this.placedUnderwater = placedUnderwater;
     this.player = player;
     this.rawPlayer = rawPlayer;
     this.itemStackBeforePlace = itemStackBeforePlace;

--- a/src/events/block-placed.ts
+++ b/src/events/block-placed.ts
@@ -6,6 +6,17 @@ import type { ItemStack } from '../item';
 import type { WorldPlayer } from '../types';
 import type { BlockType } from '../block';
 
+/**
+ * Fired when a block is placed, whether by a player or by a command.
+ *
+ * @remarks
+ * A command-driven placement carries no player: `setblock` produces a frame with only
+ * `block`, `count`, `placementMethod` and `tool`. {@link player}, {@link rawPlayer} and
+ * {@link placedUnderwater} are therefore `undefined` for those, so check `player` before
+ * reading it. Note also that `setblock <pos> air` reports as a placement of `air` rather
+ * than as a {@link BlockBrokenSignal}, and that `setblock <pos> air destroy` fires nothing
+ * at all.
+ */
 export class BlockPlacedSignal extends WorldEventSignal {
   public static readonly identifier: ServerEvent = ServerEvent.BlockPlaced;
 
@@ -13,23 +24,26 @@ export class BlockPlacedSignal extends WorldEventSignal {
 
   public readonly placedBlockType: BlockType;
 
-  public readonly placedUnderwater: boolean;
+  /** `undefined` for a command-driven placement. */
+  public readonly placedUnderwater?: boolean;
 
   public readonly placementMethod: number;
 
-  public readonly player: Player;
+  /** The player who placed the block, or `undefined` for a command-driven placement. */
+  public readonly player?: Player;
 
-  public readonly rawPlayer: WorldPlayer;
+  /** The raw player frame, or `undefined` for a command-driven placement. */
+  public readonly rawPlayer?: WorldPlayer;
 
   public readonly itemStackBeforePlace: ItemStack;
 
   public constructor(
     world: World,
     placedBlockType: BlockType,
-    placedUnderwater: boolean,
+    placedUnderwater: boolean | undefined,
     placementMethod: number,
-    player: Player,
-    rawPlayer: WorldPlayer,
+    player: Player | undefined,
+    rawPlayer: WorldPlayer | undefined,
     itemStackBeforePlace: ItemStack,
   ) {
     super(world);

--- a/src/handlers/block-placed.ts
+++ b/src/handlers/block-placed.ts
@@ -26,16 +26,16 @@ export class BlockPlacedHandler extends NetworkHandler {
     // unconditionally: reading `rawPlayer.name` threw for every `setblock`, and the
     // network layer caught that and dropped the event without emitting a signal.
     const player = rawPlayer ? world.resolvePlayer(rawPlayer.name) : undefined;
-    const itemStack = new ItemStack(tool);
+    const itemStackBeforePlace = new ItemStack(tool);
 
     new BlockPlacedSignal(
       world,
       block,
-      placedUnderWater,
       placementMethod,
+      placedUnderWater,
       player,
       rawPlayer,
-      itemStack
+      itemStackBeforePlace.isAir ? undefined : itemStackBeforePlace
     ).emit();
   }
 }

--- a/src/handlers/block-placed.ts
+++ b/src/handlers/block-placed.ts
@@ -22,7 +22,10 @@ export class BlockPlacedHandler extends NetworkHandler {
       tool,
     } = packet;
     const block = new BlockType(rawBlock);
-    const player = world.resolvePlayer(rawPlayer.name);
+    // A command-driven placement carries no player, so this cannot be resolved
+    // unconditionally: reading `rawPlayer.name` threw for every `setblock`, and the
+    // network layer caught that and dropped the event without emitting a signal.
+    const player = rawPlayer ? world.resolvePlayer(rawPlayer.name) : undefined;
     const itemStack = new ItemStack(tool);
 
     new BlockPlacedSignal(

--- a/src/network/packets/block-placed.ts
+++ b/src/network/packets/block-placed.ts
@@ -9,11 +9,19 @@ export class BlockPlacedPacket extends BasePacket {
 
   public count!: number;
 
-  public placedUnderWater!: boolean;
-  
+  /** Absent on a command-driven placement, along with {@link player}. */
+  public placedUnderWater?: boolean;
+
   public placementMethod!: number;
 
-  public player!: WorldPlayer;
+  /**
+   * The player who placed the block, or `undefined` when no player was involved.
+   *
+   * @remarks
+   * `setblock` fires this event with only `block`, `count`, `placementMethod` and `tool`.
+   * The field is not `null` in that case, it is missing from the frame entirely.
+   */
+  public player?: WorldPlayer;
 
   public tool!: WorldItemStack;
 

--- a/test/block-placed.test.mjs
+++ b/test/block-placed.test.mjs
@@ -1,0 +1,119 @@
+// Unit tests for BlockPlaced frames that carry no player.
+//
+// Measured against a live 1.21 client: `setblock` fires BlockPlaced with only
+// `block` / `count` / `placementMethod` / `tool` - no `player`, no `placedUnderWater`.
+// The handler read `packet.player.name` unconditionally, so every command-driven
+// placement threw inside the handler; the network layer caught that and dropped the
+// event, and the signal never fired. The loss was silent.
+//
+// Handlers are not exported, so these go through Server, which registers the real ones
+// and is also where the signal lands.
+//
+// Run: node test/block-placed.test.mjs   (after `tsdown`)
+
+import assert from 'node:assert/strict';
+import { BlockPlacedPacket, Packet, Server, ServerEvent } from '../dist/index.mjs';
+
+/** Captured from a live client running `setblock 69 100 -11 stone`. */
+const commandFrame = {
+  block: { aux: 0, id: 'stone', namespace: 'minecraft' },
+  count: 1,
+  placementMethod: 1,
+  tool: {
+    aux: 0, enchantments: [], freeStackSize: 255,
+    id: '', maxStackSize: 255, namespace: '', stackSize: 1,
+  },
+};
+
+/** The same event as produced by a player, which does carry a player. */
+const playerFrame = {
+  ...commandFrame,
+  placedUnderWater: false,
+  player: {
+    color: 'ffededed', dimension: 0, id: -4294967295, name: 'Kai_U',
+    position: { x: 1, y: 2, z: 3 }, type: 'minecraft:player', variant: 0, yRot: 0,
+  },
+};
+
+/**
+ * Feeds one BlockPlaced frame through the registered handler and returns the signal.
+ *
+ * The socket is never involved: a stub connection is mapped to a stub world so the
+ * handler can find both, and the signal is collected off the server's own emitter.
+ */
+function handleFrame(body) {
+  const server = new Server({ port: 0, disableEncryption: true });
+  const connection = {};
+  server.worlds.set(connection, {
+    server,
+    resolvePlayer: (name) => ({ name }),
+  });
+
+  const signals = [];
+  server.on(ServerEvent.BlockPlaced, (signal) => { signals.push(signal); });
+
+  const handler = [...server.network.handlers].find((h) => h.packet === Packet.BlockPlaced);
+  assert.ok(handler, 'BlockPlaced handler is not registered');
+
+  try {
+    handler.handle(BlockPlacedPacket.deserialize(body), connection);
+  } finally {
+    server.network.stop();
+  }
+
+  return signals;
+}
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ok   ${name}`);
+  } catch (error) {
+    failed++;
+    console.log(`  FAIL ${name}`);
+    console.log(`       ${error.message}`);
+  }
+}
+
+console.log('BlockPlaced');
+
+test('a command-driven frame emits a signal instead of throwing', () => {
+  const signals = handleFrame(commandFrame);
+
+  assert.equal(signals.length, 1, 'expected exactly one signal');
+  assert.equal(signals[0].placedBlockType.id, 'minecraft:stone');
+});
+
+test('a command-driven frame leaves player and rawPlayer undefined', () => {
+  const [signal] = handleFrame(commandFrame);
+
+  assert.equal(signal.player, undefined);
+  assert.equal(signal.rawPlayer, undefined);
+  assert.equal(signal.placedUnderwater, undefined);
+});
+
+test('a player-driven frame still resolves the player', () => {
+  const [signal] = handleFrame(playerFrame);
+
+  assert.equal(signal.player.name, 'Kai_U');
+  assert.equal(signal.rawPlayer.name, 'Kai_U');
+  assert.equal(signal.placedUnderwater, false);
+});
+
+test('placing air is reported as a placement, not as a break', () => {
+  // `setblock <pos> air` produces BlockPlaced with id "air" rather than BlockBroken.
+  // Callers that read this as "a block now exists here" need to check for it.
+  const [signal] = handleFrame({
+    ...commandFrame,
+    block: { aux: 0, id: 'air', namespace: 'minecraft' },
+  });
+
+  assert.equal(signal.placedBlockType.id, 'minecraft:air');
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exitCode = 1;


### PR DESCRIPTION
## 問題

`setblock` で発火する `BlockPlaced` には **`player` フィールドがありません**。実機（Bedrock 1.21 / `header.version` 17104896）で採ったフレームがこれです。

```json
{
  "block": { "aux": 0, "id": "stone", "namespace": "minecraft" },
  "count": 1,
  "placementMethod": 1,
  "tool": { "aux": 0, "enchantments": [], "id": "", "stackSize": 1, ... }
}
```

キーは4つだけで、`player` も `placedUnderWater` もありません。

ところがハンドラは無条件に読んでいます。

```ts
const player = world.resolvePlayer(rawPlayer.name);   // rawPlayer が undefined
```

`Network#onConnectionMessage` はハンドラの例外を catch してログに出すだけなので、**シグナルは発火せず、イベントは静かに捨てられます**。

## 見つけ方

`/setblock` を送って `BlockPlaced` が届くかを確かめたところ、**届いていました**。手で置いた場合と比べると:

| `placementMethod` | `player` | 由来 |
|---:|---|---|
| `1` | **無し** | `setblock`（コマンド） |
| `0` | **有り** | 手で設置 |

同じ接続で両方を観測しています。

ついでに分かったこととして、`setblock <pos> air` は `BlockBroken` ではなく **`block.id` が `"air"` の `BlockPlaced`** として報告され、`setblock <pos> air destroy` は**何も発火しません**。`BlockBroken` は `setblock` のどの形でも飛びませんでした。

## 修正

`player` / `rawPlayer` / `placedUnderwater` をパケットとシグナルの両方で optional にし、ハンドラはフレームが持っているときだけ解決します。

型が変わるので、`signal.player` を無条件に読んでいる利用側は**コンパイル時に気づけます**。いまは実行時に何も届かないので、そちらの方が良いと考えました。

## 併せてご検討いただきたいこと

この修正でコマンド由来の `BlockPlaced` が届くようになります。**`/setblock` を送るツールが `BlockPlaced` を購読していると、置く → イベント → また置く のループが起こりえます。**

ただし `placementMethod === 0`（または `player` の有無）で手動設置と切り分けられるので、利用側で防げます。上の表がその根拠です。

## BlockBroken について

`block-broken.ts` も同じ `rawPlayer.name` の書き方ですが、**今回は触っていません**。`BlockBroken` は実測の範囲ではプレイヤー操作でしか飛ばず、その場合は必ず `player` が入るためです。`player` 無しで届く経路を確認できていないので、推測で変えるのは避けました。

## 確認

- `test/block-placed.test.mjs` を追加（4件）。上の実測フレームをそのまま流します
- 修正を戻すと 3 件が `Cannot read properties of undefined (reading 'name')` で落ちることを確認済みです（実機で起きていた例外と同じ）
- ビルド通過、lint は警告8件・エラー0件